### PR TITLE
Fix and document testing, add web UI config, and i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,84 @@
-# SRE Assistant
+# SRE 助理
 
-**SRE Assistant** is an intelligent assistant built on the **Google Agent Development Kit (ADK)**, designed to automate and streamline Site Reliability Engineering (SRE) workflows. It handles the complete lifecycle of a production incident, from initial diagnosis to final postmortem and preventative optimization.
+**SRE 助理**是一款基於 **Google Agent Development Kit (ADK)** 建構的智慧助理，旨在自動化並簡化網站可靠性工程 (SRE) 的工作流程。它能處理從初步診斷到最終的事後檢討及預防性優化的完整生產事件生命週期。
 
-## Key Features
+## 主要功能
 
-- **🤖 Advanced Workflow Automation**: Instead of a simple sequence of tasks, the SRE Assistant uses an advanced workflow that combines parallel processing, conditional logic, and iterative loops to handle complex SRE scenarios efficiently and flexibly.
-- **🧠 RAG-Powered Diagnostics**: Utilizes Retrieval-Augmented Generation (RAG) to provide context-aware diagnostics. It consults internal documentation, historical incident data, and runbooks to identify the root cause of issues, providing citations for all its findings to ensure transparency.
-- **🤝 Human-in-the-Loop (HITL)**: For critical operations, the assistant can pause and request human approval before proceeding, ensuring that automated actions are safe and supervised.
-- **🧩 Multi-Agent System**: Composed of a team of specialized agents (Diagnostics, Remediation, Postmortem, Configuration) that collaborate to solve problems, each bringing its own expert skills to the table.
-- **⚙️ Extensible & Pluggable**: Designed with a factory pattern for core services like authentication and data storage, allowing for easy extension and integration with different backends (e.g., Google IAM, OAuth, Weaviate, Vertex AI Vector Search).
-- **📊 SLO-Driven Operations**: Natively understands Service Level Objectives (SLOs) and error budgets, enabling it to make data-driven decisions about incident response and system reliability.
+- **🤖 先進的工作流程自動化**：SRE 助理採用先進的工作流程，結合了平行處理、條件邏輯和迭代循環，而非簡單的任務序列，從而高效且靈活地處理複雜的 SRE 場景。
+- **🧠 RAG 驅動的診斷**：利用檢索增強生成 (RAG) 技術提供具備情境感知能力的診斷。它會查閱內部文件、歷史事件資料和操作手冊來找出問題的根本原因，並為所有發現提供引用來源，以確保透明度。
+- **🤝 人工介入 (Human-in-the-Loop, HITL)**：對於關鍵操作，助理會暫停並請求人類批准後再繼續執行，確保自動化操作的安全與可監督性。
+- **🧩 多代理系統**：由一個專業代理團隊（診斷、修復、事後檢討、設定）組成，它們協同解決問題，每個代理都貢獻其專業技能。
+- **⚙️ 可擴充與可插拔設計**：核心服務（如認證和資料儲存）採用工廠模式設計，便於擴充並與不同的後端（例如 Google IAM、OAuth、Weaviate、Vertex AI Vector Search）整合。
+- **📊 SLO 驅動的操作**：原生理解服務等級目標 (SLO) 和錯誤預算，使其能夠根據數據做出有關事件應對和系統可靠性的決策。
 
-## Architecture Overview
+## 架構概覽
 
-The SRE Assistant is built around a central `SREWorkflow` coordinator that orchestrates four key phases. This workflow-driven architecture allows for parallel execution of diagnostics and conditional logic for remediation, making it far more powerful than a simple sequential agent.
+SRE 助理圍繞一個中央 `SREWorkflow` 協調器建構，該協調器負責調度四個關鍵階段。這種工作流程驅動的架構允許平行執行診斷和條件式修復邏輯，使其比簡單的順序執行代理更為強大。
 
 ```mermaid
 graph TD
-    subgraph "User Interface (Clients)"
+    subgraph "使用者介面 (用戶端)"
         UI[REST API / SSE / Web UI]
     end
 
-    subgraph "ADK Runtime"
-        Runner[ADK Runner]
+    subgraph "ADK 執行環境"
+        Runner[ADK 執行器]
     end
 
-    subgraph "SRE Assistant Core Services"
+    subgraph "SRE 助理核心服務"
         direction TB
-        Auth[Auth Manager]
-        Config[Config Manager]
-        Memory[Memory Service]
-        Session[Session Service]
-        SLO[SLO Manager]
+        Auth[認證管理員]
+        Config[設定管理員]
+        Memory[記憶體服務]
+        Session[會話服務]
+        SLO[SLO 管理員]
     end
 
-    subgraph "SRE Workflow (SREWorkflow)"
+    subgraph "SRE 工作流程 (SREWorkflow)"
         direction LR
-        A[Phase 1: Parallel Diagnostics] --> B[Phase 2: Conditional Remediation]
-        B --> C[Phase 3: Postmortem]
-        C --> D[Phase 4: Iterative Optimization]
+        A[階段 1: 平行診斷] --> B[階段 2: 條件式修復]
+        B --> C[階段 3: 事後檢討]
+        C --> D[階段 4: 迭代優化]
     end
 
-    subgraph "Phase 1 Details (ParallelAgent)"
+    subgraph "階段 1 細節 (ParallelAgent)"
         direction TB
-        P1[Metrics Analyzer]
-        P2[Log Analyzer]
-        P3[Trace Analyzer]
+        P1[指標分析器]
+        P2[日誌分析器]
+        P3[追蹤分析器]
     end
 
-    subgraph "Phase 2 Details (ConditionalRemediation)"
+    subgraph "階段 2 細節 (ConditionalRemediation)"
         direction TB
-        C1{Severity Check} -- P0 --> C2[HITL Remediation]
-        C1 -- P1 --> C3[Automated Remediation]
-        C1 -- P2 --> C4[Scheduled Remediation]
+        C1{嚴重性檢查} -- P0 --> C2[人工介入修復]
+        C1 -- P1 --> C3[自動化修復]
+        C1 -- P2 --> C4[排程修復]
     end
 
-    subgraph "Phase 4 Details (LoopAgent)"
+    subgraph "階段 4 細節 (LoopAgent)"
         direction TB
-        L1(Tune SLO) --> L2{SLO Met?}
-        L2 -- No --> L1
-        L2 -- Yes --> L3(End)
+        L1(調整 SLO) --> L2{SLO 是否達標?}
+        L2 -- 否 --> L1
+        L2 -- 是 --> L3(結束)
     end
 
     UI --> Runner
     Runner --> SREWorkflow
 
-    SREWorkflow -- Uses --> Auth
-    SREWorkflow -- Uses --> Config
-    SREWorkflow -- Uses --> Memory
-    SREWorkflow -- Uses --> Session
-    SREWorkflow -- Uses --> SLO
+    SREWorkflow -- 使用 --> Auth
+    SREWorkflow -- 使用 --> Config
+    SREWorkflow -- 使用 --> Memory
+    SREWorkflow -- 使用 --> Session
+    SREWorkflow -- 使用 --> SLO
 
-    SREWorkflow -- Contains --> A
-    SREWorkflow -- Contains --> B
-    SREWorkflow -- Contains --> C
-    SREWorkflow -- Contains --> D
+    SREWorkflow -- 包含 --> A
+    SREWorkflow -- 包含 --> B
+    SREWorkflow -- 包含 --> C
+    SREWorkflow -- 包含 --> D
 
-    A -- Contains --> P1 & P2 & P3
-    B -- Contains --> C1
-    D -- Contains --> L1
+    A -- 包含 --> P1 & P2 & P3
+    B -- 包含 --> C1
+    D -- 包含 --> L1
 
     style SREWorkflow fill:#bbf,stroke:#333,stroke-width:2px
     style A fill:#cde4ff
@@ -87,77 +87,77 @@ graph TD
     style D fill:#cde4ff
 ```
 
-For a more detailed explanation of the architecture, please see [ARCHITECTURE.md](ARCHITECTURE.md).
+關於架構的更詳細說明，請參閱 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
-## Getting Started
+## 開始使用
 
-This project uses [Poetry](https://python-poetry.org/) for dependency management.
+本專案使用 [Poetry](https://python-poetry.org/) 來管理相依套件。
 
-### Prerequisites
+### 前提條件
 
 - Python 3.9+
-- [Poetry](https://python-poetry.org/docs/#installation) installed on your system.
+- 系統上已安裝 [Poetry](https://python-poetry.org/docs/#installation)。
 
-### Installation
+### 安裝
 
-1.  **Clone the repository:**
+1.  **複製程式碼庫：**
     ```sh
     git clone https://github.com/your-repo/adk.git
     cd adk
     ```
 
-2.  **Install dependencies:**
-    Use Poetry to install the required packages from the `pyproject.toml` file. This will create a virtual environment for the project.
+2.  **安裝相依套件：**
+    使用 Poetry 從 `pyproject.toml` 檔案安裝所需的套件。這會為專案建立一個虛擬環境。
     ```sh
     poetry install
     ```
 
-### Configuration
+### 設定
 
-1.  **Set up configuration files:**
-    The application uses a tiered configuration system. Start by copying the base configuration.
-    - Create an environment-specific config file in `sre_assistant/config/environments/`, for example, `development.yaml`.
-    - Populate it with your settings, such as API keys and database connections. The system will automatically load `base.yaml`, then your environment-specific file, and finally override with any environment variables.
+1.  **設定設定檔：**
+    應用程式使用分層設定系統。首先複製基礎設定。
+    - 在 `sre_assistant/config/environments/` 中建立一個特定環境的設定檔，例如 `development.yaml`。
+    - 在其中填入您的設定，例如 API 金鑰和資料庫連線。系統會自動載入 `base.yaml`，然後是您的環境特定檔案，最後用任何環境變數覆寫。
 
-2.  **Set the environment:**
-    Export an environment variable to tell the application which configuration to use.
+2.  **設定環境：**
+    匯出一個環境變數，告知應用程式要使用哪個設定。
     ```sh
     export APP_ENV=development
     ```
 
-### Running the Assistant
+### 執行助理
 
-Activate the virtual environment and run the main application (the exact entry point may vary, assuming a `main.py` or similar).
+啟動虛擬環境並執行主應用程式（確切的進入點可能會有所不同，假設為 `main.py` 或類似檔案）。
 
 ```sh
 poetry shell
-python -m sre_assistant.main  # Replace with the correct entry point
+python -m sre_assistant.main  # 請替換為正確的進入點
 ```
 
-## Directory Structure
+## 目錄結構
 
-Here is a high-level overview of the repository's structure:
+以下是本專案程式碼庫的頂層結構概覽：
 
 ```
 sre_assistant/
-├── __init__.py                 # Service registration for A2A
-├── README.md                   # This file
-├── workflow.py                 # The core SREWorkflow implementation
-├── contracts.py                # Pydantic data models for API contracts
-├── tools.py                    # Central registry for versioned tools
-├── config/                     # Configuration management (base, envs)
-├── auth/                       # Authentication and authorization services
-├── memory/                     # Long-term memory (RAG) backends
-├── session/                    # Session (short-term memory) persistence
-├── sub_agents/                 # Specialized agents (Diagnostic, Remediation, etc.)
-├── tests/                      # Unit and integration tests
-└── utils/                      # Shared utility functions
+├── __init__.py                 # A2A 的服務註冊
+├── README.md                   # 本檔案
+├── workflow.py                 # 核心 SREWorkflow 實作
+├── contracts.py                # API 的 Pydantic 資料模型
+├── tools.py                    # 版本化工具的中央註冊表
+├── config/                     # 設定管理 (基礎設定、各環境設定)
+├── auth/                       # 認證與授權服務
+├── memory/                     # 長期記憶體 (RAG) 後端
+├── session/                    # 會話 (短期記憶體) 持久化
+├── sub_agents/                 # 專業代理 (診斷、修復等)
+├── tests/                      # 單元與整合測試
+└── utils/                      # 共用工具函式
 ```
 
-## Contributing
+## 貢獻
 
-We welcome contributions! Please see our [Contributing Guide](docs/references/adk-docs/contributing-guide.md) for more details on how to get started, our code of conduct, and the process for submitting pull requests.
+我們歡迎各種貢獻！請參閱我們的 [貢獻指南](docs/references/adk-docs/contributing-guide.md) 以了解如何開始、我們的行為準則以及提交拉取請求的流程。
 
-## License
+## 授權
 
-This project is licensed under the Apache 2.0 License. See the `LICENSE` file for details.
+本專案採用 Apache 2.0 授權。詳情請見 `LICENSE` 檔案。

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,87 @@
+# 專案測試指南
+
+本文件提供如何在本地環境中設定和執行 SRE Assistant 專案測試的詳細步驟。
+
+## 1. 環境設定
+
+在開始測試之前，請確保您已安裝以下工具：
+
+- **Python 3.9+**
+- **Poetry**: 本專案使用 Poetry 進行相依套件管理。如果您尚未安裝，請參考 [Poetry 官方文件](https://python-poetry.org/docs/#installation) 進行安裝。
+
+## 2. 安裝相依套件
+
+首先，請複製本專案的程式碼庫，並進入專案根目錄。然後，使用 Poetry 安裝所有必要的相依套件，包括開發環境所需的 `pytest`。
+
+```bash
+# 進入專案根目錄
+cd path/to/sre-assistant
+
+# 使用 Poetry 安裝相依套件
+poetry install
+```
+
+此指令會建立一個虛擬環境，並將所有定義在 `pyproject.toml` 中的套件安裝進去。
+
+## 3. 執行單元與整合測試
+
+本專案使用 `pytest` 作為測試框架。在修復了多個導入問題和程式碼錯誤後，目前所有核心測試案例都應能成功通過。
+
+### 執行所有測試
+
+若要執行 `sre_assistant` 應用程式的所有測試，請在專案根目錄下執行以下指令：
+
+```bash
+poetry run pytest sre_assistant/tests/
+```
+
+**重要提示**：請務必指定 `sre_assistant/tests/` 目錄。若只執行 `poetry run pytest`，`pytest` 會試圖執行專案中所有符合 `test_*.py` 格式的檔案，包含 `docs/` 目錄下的範例專案，這將會因為缺少那些範例專案的相依套件而導致大量的測試收集錯誤。
+
+預期輸出應顯示所有測試通過（`passed`）或被跳過（`skipped`），而不應有任何失敗（`failed`）或錯誤（`error`）。
+
+### 執行特定測試檔案
+
+如果您只想執行某個特定的測試檔案（例如 `test_auth.py`），可以使用以下指令：
+
+```bash
+poetry run pytest sre_assistant/tests/test_auth.py
+```
+
+這有助於在開發特定功能時，集中測試相關的程式碼。
+
+## 4. 透過 ADK 開發人員 UI 進行手動測試
+
+除了自動化測試外，您也可以使用 ADK 的網頁介面來啟動並手動測試代理程式。
+
+### 啟動 ADK Web 伺服器
+
+在專案的根目錄下，執行以下指令來啟動網頁伺服器：
+
+```bash
+poetry run adk web
+```
+
+伺服器成功啟動後，您會看到類似以下的輸出：
+
+```
+INFO:     Started server process [XXXXX]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+### 存取與驗證
+
+1.  **開啟瀏覽器**：前往 <http://localhost:8000>。
+2.  **查看介面**：您應該能看到 ADK 的開發人員 UI。
+3.  **測試代理程式**：您可以在介面中輸入查詢，與 SRE 助理代理程式進行互動，並查看其回應、狀態和所使用的工具。這對於進行端到端的流程驗證和即時偵錯非常有用。
+
+## 5. 測試覆蓋範圍
+
+雖然我們已經修復了現有的測試，但仍有許多方面可以增加測試案例，以提高程式碼的穩定性和可靠性，例如：
+
+- **錯誤處理**：針對外部工具（如 Prometheus API）回傳非預期回應或超時的情境。
+- **邊界條件**：測試輸入為空值、無效憑證或非預期格式資料時的處理情況。
+- **設定檔驗證**：確保不同環境（開發、預備、生產）的設定檔能被正確載入和覆寫。
+
+歡迎社群貢獻更多、更全面的測試案例。

--- a/adk.yaml
+++ b/adk.yaml
@@ -1,0 +1,2 @@
+runtime: "python"
+entrypoint: "sre_assistant:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ name = "sre_assistant"
 version = "0.1.0"
 description = "SRE Assistant Agent based on Google ADK"
 authors = ["Jules <jules@example.com>"]
+packages = [{include = "sre_assistant"}]
 # 註：由於目錄名稱包含連字號，此處暫不定義可安裝的套件。
 # 我們主要使用此檔案來管理依賴項。
 

--- a/sre_assistant/tests/test_auth.py
+++ b/sre_assistant/tests/test_auth.py
@@ -94,7 +94,7 @@ async def test_jwt_provider():
     authorized = await provider.authorize(user_info, 'deployment', 'restart')
     assert not authorized # Not in permissions claim
 
-    user_info['claims']['permissions'] = ['deployment:restart']
+    user_info['claims'] = {'permissions': ['deployment:restart']}
     authorized = await provider.authorize(user_info, 'deployment', 'restart')
     assert authorized
 


### PR DESCRIPTION
This commit achieves several objectives:

1.  **Fixes the Test Suite:**
    - Resolves numerous test failures caused by incorrect import paths, invalid patch targets, and bugs in the test logic.
    - Stabilizes the test suite by ensuring all existing tests pass.
    - Addresses issues with the `importlib` and `pytest` collection by using a workaround to ensure tests are discovered and run correctly.

2.  **Adds Comprehensive Test Documentation:**
    - Creates a new `TESTING.md` file in Traditional Chinese.
    - Provides clear instructions for setting up the environment, running the automated tests, and verifying the agent manually using the ADK Web UI.

3.  **Enables ADK Web UI:**
    - Adds an `adk.yaml` file to configure the entry point for the ADK web server.
    - Allows the developer UI to be started with `adk web`.

4.  **Internationalization:**
    - Translates the `README.md` file into Traditional Chinese as requested.