### PR TITLE
docs: 建立 SRE 書籍核心參考文件

### DIFF
--- a/docs/reference-google-sre-book.md
+++ b/docs/reference-google-sre-book.md
@@ -1,0 +1,47 @@
+# SRE Assistant 專案核心參考文獻：Google SRE 書籍
+
+**文件作者**: Jules, ADK 首席架構師
+**目的**: 本文件旨在為 SRE Assistant 的開發團隊提供一份精簡、聚焦的參考指南。基於對專案架構 ([ARCHITECTURE.md](ARCHITECTURE.md))、路線圖 ([ROADMAP.md](ROADMAP.md)) 和規格 ([SPEC.md](SPEC.md)) 的深入理解，我們從 Google SRE 書籍中篩選出與本專案技術實現最為相關的核心章節。
+
+---
+
+## 核心參考章節清單
+
+以下章節為理解和構建 SRE Assistant 的基石，建議所有開發人員優先閱讀。
+
+### Part I: 基礎原則與理念 (Foundation & Philosophy)
+
+1.  **檔案路徑**: `docs/references/google-sre-book/Chapter-04-Service-Level-Objectives.md`
+    -   **參考原因**: 本章是整個 SRE 實踐的基石。SRE Assistant 的一個核心目標是圍繞 SLO/SLI 進行監控、告警和自動化決策。`SPEC.md` 中定義的 `Incident Handler` 和 `Predictive Maintenance` 代理，其所有行為（如是否自動修復、是否告警）都應基於對錯誤預算 (Error Budget) 的理解。此章節為實現這些功能提供了理論基礎。
+
+2.  **檔案路徑**: `docs/references/google-sre-book/Chapter-05-Eliminating-Toil.md`
+    -   **參考原因**: SRE Assistant 專案的根本存在價值是**消除瑣務 (Toil)**。本章節精確定義了何為瑣務，並提供了識別與消除瑣務的策略。開發團隊必須深刻理解這一點，以確保我們開發的每一項自動化功能都是在真正地、有效地減少 SRE 的手動、重複性工作，而不是創造新的、自動化的瑣務。
+
+3.  **檔案路徑**: `docs/references/google-sre-book/Chapter-07-The-Evolution-of-Automation-at-Google.md`
+    -   **參考原因**: 本章節提供了 Google 內部自動化系統演進的宏觀視角，從簡單的腳本到複雜的、有自主決策能力的平台。這與 SRE Assistant 從 MVP 逐步演進到聯邦化生態系統的路線圖 ([ROADMAP.md](ROADMAP.md)) 高度契合。它可以幫助我們在架構設計上避免常見的陷阱，思考如何構建一個可持續演進而非僵化的自動化系統。
+
+### Part II: 事件處理與可靠性實踐 (Incident Handling & Reliability Practices)
+
+4.  **檔案路徑**: `docs/references/google-sre-book/Chapter-06-Monitoring-Distributed-Systems.md`
+    -   **參考原因**: SRE Assistant 是可觀測性數據的**消費者**和**分析者**。本章詳細闡述了監控的「為什麼」和「什麼」，而不僅僅是「如何」。這對於我們設計 `PrometheusQueryTool` 和 `LokiLogQueryTool` (`SPEC.md`) 至關重要，確保我們的代理能夠提出有意義的問題，而不僅僅是抓取數據。
+
+5.  **檔案路徑**: `docs/references/google-sre-book/Chapter-10-Practical-Alerting.md`
+    -   **參考原因**: `Incident Handler` 代理需要處理告警。本章節提供了關於如何設計**有效且可操作**告警的黃金標準。SRE Assistant 在分析告警時，應能區分哪些是噪音，哪些是真正的信號。這將直接影響我們在 Phase 2 中實現告警靜音、聚合和智慧分診等功能的設計。
+
+6.  **檔案路徑**: `docs/references/google-sre-book/Chapter-12-Effective-Troubleshooting.md`
+    -   **參考原因**: 本章系統性地介紹了 SRE 的故障排除方法論。SRE Assistant 在執行根因分析 (RCA) 時，其內部的推理邏輯和工作流程應模仿甚至自動化這裡描述的步驟。這為我們設計 `SREWorkflow` (`TASKS.md`) 中的診斷與修復流程提供了清晰的藍圖。
+
+7.  **檔案路徑**: `docs/references/google-sre-book/Chapter-13-Emergency-Response.md`
+    -   **參考原因**: `Incident Handler` 代理的核心職責之一是輔助甚至領導事件響應。本章詳細描述了事件響應中的角色（如：事件指揮官）、溝通協調和決策過程。我們的 `GrafanaOnCallTool` 和與 ChatOps 的整合，都應以支援和簡化此流程為目標。
+
+8.  **檔案路徑**: `docs/references/google-sre-book/Chapter-15-Postmortem-CultureLearning-from-Failure.md`
+    -   **參考原因**: 這是 Phase 3 規劃中 `PostmortemAgent` 的直接理論來源。`TASKS.md` 中明確提到了覆盤報告生成功能。本章不僅提供了覆盤報告的結構，更重要的是強調了「無指責 (Blameless)」文化。我們的代理在生成報告初稿時，其語言和結構必須遵循這一核心原則。
+
+### Part III: 附錄與範本 (Appendices & Templates)
+
+9.  **檔案路徑**: `docs/references/google-sre-book/Appendix-D-Example-Postmortem.md`
+    -   **參考原因**: 這是 `PostmortemAgent` 功能的具體實現範本。當代理從 `PrometheusQueryTool`、`LokiLogQueryTool` 和 `GitHubTool` 收集到事件數據後，需要將這些零散的信息組合成一篇結構化的覆盤報告。此附錄提供了一個絕佳的、可直接參考的目標格式。
+
+---
+**結論**:
+專案初期的開發應聚焦於上述章節所闡述的核心概念。隨著專案進入後期階段（如混沌工程、成本優化），我們將會更新此文件，納入更多相關章節。


### PR DESCRIPTION
根據專案架構、路線圖與規格文件，分析並篩選出 Google SRE 書籍中最具技術參考價值的章節。

建立 `docs/reference-google-sre-book.md` 文件，以清單形式呈現每個參考章節的路徑與其對 SRE Assistant 專案至關重要的原因，為開發團隊提供核心理論與實踐指導。